### PR TITLE
Switch default installation to next-gen xp-runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-script: rake lint syntax validate spec
+script: bundle exec rake lint syntax validate spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (3.2.0)
+      json_pure
+    json_pure (1.8.3)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    puppet (4.5.1)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.1.0)
+      rake
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (11.1.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.4.0)
+      rspec
+    rspec-support (3.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  facter (>= 1.7.0)
+  puppet (>= 3.3)
+  puppet-lint (>= 1.0.0)
+  puppetlabs_spec_helper (>= 0.8.2)
+  rake
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-framework/puppet-xp-runners.png)](http://travis-ci.org/xp-framework/puppet-xp-runners)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
 
-This puppet module installs xp-runners, see https://github.com/xp-framework/xp-runners.
-
+This puppet module installs xp-runners, see https://github.com/xp-runners/reference.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,12 +47,12 @@
 # Copyright 2015, 2016 Frank Kleine
 #
 class xp_runners (
-  $manage_package_repo  = $xp_runners::params::manage_package_repo,
-  $repo_location = $xp_runners::params::repo_location,
-  $repo_release = $xp_runners::params::repo_release,
-  $repo_repos = $xp_runners::params::repo_repos,
-  $repo_key_id = $xp_runners::params::repo_key_id,
-  $repo_key_source = $xp_runners::params::repo_key_source,
+  $manage_package_repo = $xp_runners::params::manage_package_repo,
+  $repo_location       = $xp_runners::params::repo_location,
+  $repo_release        = $xp_runners::params::repo_release,
+  $repo_repos          = $xp_runners::params::repo_repos,
+  $repo_key_id         = $xp_runners::params::repo_key_id,
+  $repo_key_source     = $xp_runners::params::repo_key_source,
   $repo_requires_https = $xp_runners::params::repo_requires_https,
 ) inherits xp_runners::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,29 @@
 #
 # * `manage_package_repo`
 #   Switch whether the XP-Runners repository should be used. Optional, defaults
-#   to true.
+#   to true. All remaining parameters are ignored when this is set to false.
+#
+# * `repo_location`
+#   URL of repository where xp-runners can be found. Optional, defaults
+#   to https://dl.bintray.com/xp-runners/debian.
+#
+# * `repo_release`
+#   Which Debian release the package should be chosen for. Optional, defaults
+#   to jessie.
+#
+# * `repo_repos`
+#   Which Debian release repository the package should be chosen from. Optional,
+#   defaults to main.
+#
+# * `repo_key_id`
+#   ID of repository key. Optional, defaults to key of default repo_location.
+#
+# * `repo_key_source`
+#   Where to find the repository key. Optional, defaults to key of default
+#   repo_location.
+#
+# * `repo_requires_https`
+#   Whether repo_location requires https transport. Optional, defaults to true.
 #
 # Authors
 # -------
@@ -24,12 +46,19 @@
 #
 class xp_runners (
   $manage_package_repo  = $xp_runners::params::manage_package_repo,
+  $repo_location = $xp_runners::params::repo_location,
+  $repo_release = $xp_runners::params::repo_release,
+  $repo_repos = $xp_runners::params::repo_repos,
+  $repo_key_id = $xp_runners::params::repo_key_id,
+  $repo_key_source = $xp_runners::params::repo_key_source,
+  $repo_requires_https = $xp_runners::params::repo_requires_https,
 ) inherits xp_runners::params {
 
   include xp_runners::install
 
   validate_bool($manage_package_repo)
   if $manage_package_repo {
+    validate_bool($repo_requires_https)
     include xp_runners::repository
 
     anchor { '::xp_runners::begin': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,10 @@
 #
 # This module depends on puppetlabs-apt.
 #
+# In order to let the module install xp-framework/core as a global package as a
+# global Composer package it expects that Composer is already installed, most
+# likely through another Puppet module.
+#
 # Parameters
 # ----------
 #
@@ -36,6 +40,17 @@
 #   You should set this to false in case your repo_location doesn't require
 #   https.
 #
+# * `composer_home`
+#   Composer home path as defined in `COMPOSER_HOME` environment variable.
+#   Optional, undefined by default. When specified the module will try to
+#   install xp-framework/core as a global package.
+#
+# * `composer_path`
+#   Path to Composer binary. Optional, defaults to 'composer'. You might want to
+#   change this to an absolute path if your Composer binary is not in one of the
+#   default pathes, which are /bin, /sbin, /usr/bin, /usr/sbin/ and
+#   /usr/local/bin/, or if your binary is 'composer.phar'.
+#
 # Authors
 # -------
 #
@@ -54,6 +69,8 @@ class xp_runners (
   $repo_key_id         = $xp_runners::params::repo_key_id,
   $repo_key_source     = $xp_runners::params::repo_key_source,
   $repo_requires_https = $xp_runners::params::repo_requires_https,
+  $composer_home       = undef,
+  $composer_path       = $xp_runners::params::composer_path,
 ) inherits xp_runners::params {
 
   include xp_runners::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,8 @@
 #
 # * `repo_requires_https`
 #   Whether repo_location requires https transport. Optional, defaults to true.
+#   You should set this to false in case your repo_location doesn't require
+#   https.
 #
 # Authors
 # -------

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,8 @@ class xp_runners::install {
     exec { 'composer global require xp-framework/core':
       command     => "${xp_runners::composer_path} global require xp-framework/core",
       path        => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ],
-      environment => ["COMPOSER_HOME=${xp_runners::composer_home}"]
+      environment => ["COMPOSER_HOME=${xp_runners::composer_home}"],
+      creates     => "${xp_runners::composer_home}/vendor/xp-framework/core/composer.json"
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,7 +17,14 @@ class xp_runners::install {
 
   package { 'xp-runners':
     ensure => latest,
-    tag    => 'xp_runners_repo'
+    tag    => 'xp_runners_repo',
+  }
+
+  if $xp_runners::composer_home {
+    exec { 'composer global require xp-framework/core':
+      command     => "${xp_runners::composer_path} global require xp-framework/core",
+      path        => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ],
+      environment => ["COMPOSER_HOME=${xp_runners::composer_home}"]
+    }
   }
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,11 +15,11 @@
 #
 class xp_runners::params {
 
-  $manage_package_repo = true,
-  $repo_location = 'https://dl.bintray.com/xp-runners/debian',
-  $repo_release = 'jessie',
-  $repo_repos = 'main',
-  $repo_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61',
-  $repo_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray',
-  $repo_requires_https = true,
+  $manage_package_repo = true
+  $repo_location = 'https://dl.bintray.com/xp-runners/debian'
+  $repo_release = 'jessie'
+  $repo_repos = 'main'
+  $repo_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
+  $repo_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
+  $repo_requires_https = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,10 @@
 class xp_runners::params {
 
   $manage_package_repo = true
-
+  $repo_location = 'https://dl.bintray.com/xp-runners/debian',
+  $repo_release = 'jessie',
+  $repo_repos = 'main',
+  $repo_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61',
+  $repo_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray',
+  $repo_requires_https = true,
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,10 +16,10 @@
 class xp_runners::params {
 
   $manage_package_repo = true
-  $repo_location = 'https://dl.bintray.com/xp-runners/debian'
-  $repo_release = 'jessie'
-  $repo_repos = 'main'
-  $repo_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
-  $repo_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
+  $repo_location       = 'https://dl.bintray.com/xp-runners/debian'
+  $repo_release        = 'jessie'
+  $repo_repos          = 'main'
+  $repo_key_id         = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
+  $repo_key_source     = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
   $repo_requires_https = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class xp_runners::params {
   $repo_key_id         = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
   $repo_key_source     = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
   $repo_requires_https = true
+  $composer_path       = 'composer'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@
 #
 class xp_runners::params {
 
-  $manage_package_repo = true
+  $manage_package_repo = true,
   $repo_location = 'https://dl.bintray.com/xp-runners/debian',
   $repo_release = 'jessie',
   $repo_repos = 'main',

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -15,21 +15,29 @@
 #
 class xp_runners::repository {
 
-  # repository with xp-runners requires https
-  ensure_packages(['apt-transport-https'])
-
   include ::apt
 
-  # make xp_runners repository available
-  apt::source { 'xp_runners_repo':
-    location => 'https://dl.bintray.com/xp-framework/xp-runners',
-    release  => 'jessie',
-    repos    => 'main',
-    key      => {
-      id     => '8756C4F765C9AC3CB6B85D62379CE192D401AB61',
-      source => 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray',
-    },
-    require  => Package['apt-transport-https']
+  if $xp_runners::repo_requires_https {
+    ensure_packages(['apt-transport-https'])
+    apt::source { 'xp_runners_repo':
+      location => $xp_runners::repo_location,
+      release  => $xp_runners::repo_release,
+      repos    => $xp_runners::repo_repos,
+      key      => {
+        id     => $xp_runners::repo_key_id,
+        source => $xp_runners::repo_key_source,
+      },
+      require  => Package['apt-transport-https']
+    }
+  } else {
+    apt::source { 'xp_runners_repo':
+      location => $xp_runners::repo_location,
+      release  => $xp_runners::repo_release,
+      repos    => $xp_runners::repo_repos,
+      key      => {
+        id     => $xp_runners::repo_key_id,
+        source => $xp_runners::repo_key_source,
+      }
+    }
   }
 }
-


### PR DESCRIPTION
These changes lead to a installation of the next-gen xp-runners from https://github.com/xp-runners/reference by default instead of the previous version.

However, by making the actual repository to install the package from configurable users will still be able to install the old version by supplying the old repository url.

This adresses both issues #1 and #3.
